### PR TITLE
Refactor Missile explosion handling for consistency

### DIFF
--- a/missile.py
+++ b/missile.py
@@ -14,10 +14,9 @@ class Missile(GameObject):
         self.target_x = target_x
         self.target_y = target_y
         self.speed = MISSILE_SPEED
-        self.explosion = None
         self.angle = math.atan2(target_y - self.start_y, target_x - self.start_x)
 
-    def update(self):
+    def update(self, explosions_list):
         if not self.is_alive:
             return
 
@@ -29,7 +28,7 @@ class Missile(GameObject):
             self.x = self.target_x
             self.y = self.target_y
             self.is_alive = False
-            self.explosion = Explosion(self.x, self.y)
+            explosions_list.append(Explosion(self.x, self.y))
         else:
             self.x += self.speed * math.cos(self.angle)
             self.y += self.speed * math.sin(self.angle)

--- a/missile_manager.py
+++ b/missile_manager.py
@@ -17,11 +17,9 @@ class MissileManager:
 
         updated_missiles = []
         for missile in self.missiles:
-            missile.update()
+            missile.update(self.explosions)
             if missile.is_alive:
                 updated_missiles.append(missile)
-            elif missile.explosion:
-                self.explosions.append(missile.explosion)
         self.missiles[:] = updated_missiles
 
         updated_explosions = []

--- a/test_missile.py
+++ b/test_missile.py
@@ -3,6 +3,7 @@ import pyxel
 import math
 from unittest.mock import patch
 from missile import Missile
+from explosion import Explosion # Ensuring this import is present
 from base import Base
 from constants import *
 
@@ -16,11 +17,14 @@ class TestMissile(unittest.TestCase):
         self.assertEqual(missile.target_y, 100)
         self.assertEqual(missile.speed, MISSILE_SPEED)
         self.assertTrue(missile.is_alive)
-        self.assertIsNone(missile.explosion)
+        # self.assertIsNone(missile.explosion) # Removed
 
     def test_missile_update_reach_target(self):
         base = Base(100)
         missile = Missile(base, 105, BASE_Y)
-        missile.update()
+        explosions_list = [] # Added
+        missile.update(explosions_list) # Changed
         self.assertFalse(missile.is_alive)
-        self.assertIsNotNone(missile.explosion)
+        # self.assertIsNotNone(missile.explosion) # Removed
+        self.assertEqual(len(explosions_list), 1) # Added
+        self.assertIsInstance(explosions_list[0], Explosion) # Added


### PR DESCRIPTION
I modified the Missile and MissileManager classes to make the creation and handling of Explosion objects more consistent with the Meteor class.

- Missile.update() now directly appends a new Explosion to a shared list (passed as a parameter), instead of storing it in an instance attribute.
- MissileManager.update() now passes the shared explosions list to Missile.update() and no longer needs to explicitly retrieve the explosion from the missile instance.
- I removed the `explosion` attribute from the Missile class.
- I updated tests in `test_missile.py` to reflect these changes, ensuring that explosions are correctly registered in the shared list.

This refactoring simplifies the explosion management logic and makes the code for Missiles and Meteors more aligned in how they report explosions.